### PR TITLE
Online orders cities

### DIFF
--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
@@ -93,6 +93,7 @@ public class DatagenSourceConfig {
     public static final String CONFIG_ONLINEORDERS_ADDRESS_PHONES_MAX   = "onlineorders.address.phones.max";
     public static final String CONFIG_ONLINEORDERS_REUSE_ADDRESS_RATIO  = "onlineorders.reuse.address.ratio";
     public static final String CONFIG_ONLINEORDERS_OUTOFSTOCK_RATIO     = "onlineorders.outofstock.ratio";
+    public static final String CONFIG_ONLINEORDERS_CITIES               = "onlineorders.cities";
 
     private static final String CONFIG_GROUP_OUTOFSTOCKS = "Out-of-stocks";
     public static final String CONFIG_OUTOFSTOCKS_RESTOCKING_MIN_DELAY  = "outofstocks.restocking.delay.days.min";
@@ -498,6 +499,13 @@ public class DatagenSourceConfig {
                     Importance.LOW,
                     "Ratio of orders that have at least one product that runs out-of-stock after the order has been placed. Must be between 0 and 1.",
                     CONFIG_GROUP_ONLINEORDERS, 8, Width.SHORT, "Out-of-stock product ratio")
+        .define(CONFIG_ONLINEORDERS_CITIES,
+                    Type.LIST,
+                    new ArrayList<String>(),
+                    new NonNullValidator(),
+                    Importance.LOW,
+                    "List of cities used for generated online orders",
+                    CONFIG_GROUP_ONLINEORDERS, 9, Width.LONG, "Cities for online orders")
         //
         // Generating out-of-stock events
         //

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
@@ -15,6 +15,7 @@
  */
 package com.ibm.eventautomation.demos.loosehangerjeans;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Address.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Address.java
@@ -37,7 +37,7 @@ public class Address {
     private final String street;
 
     /** The city of the address. */
-    private final String city;
+    private String city;
 
     /** The zipcode of the address. */
     private final String zipcode;
@@ -104,6 +104,10 @@ public class Address {
 
     public String getCity() {
         return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
     }
 
     public String getZipcode() {

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/OnlineOrderGenerator.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/OnlineOrderGenerator.java
@@ -125,6 +125,8 @@ public class OnlineOrderGenerator {
         this.duplicatesRatio = config.getDouble(DatagenSourceConfig.CONFIG_DUPLICATE_ONLINEORDERS);
 
         this.MAX_DELAY_SECS = config.getInt(DatagenSourceConfig.CONFIG_DELAYS_ONLINEORDERS);
+
+        this.cities = config.getList(DatagenSourceConfig.CONFIG_ONLINEORDERS_CITIES);
     }
 
     /** Generates a random online order. */

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/OnlineOrderGenerator.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/OnlineOrderGenerator.java
@@ -72,6 +72,9 @@ public class OnlineOrderGenerator {
     /** Formatter for event timestamps. */
     private final DateTimeFormatter timestampFormatter;
 
+    //** Custom list of cities to be used instead of faker generated */
+    private final List<String> cities;
+
     /**
      * Generator can simulate a source of events that offers
      *  at-least-once delivery semantics by occasionally
@@ -141,6 +144,13 @@ public class OnlineOrderGenerator {
 
         // Generate a random shipping address.
         Address shippingAddress = Address.create(faker, country, minPhones, maxPhones);
+
+        // If the city list is not empty, we will randomly select a city 
+        // and replace one created by the faker
+        if(cities.size() > 0) {
+            String city = Generators.randomItem(cities);
+            shippingAddress.setCity(city);
+        }
 
         // Possibly reuse the shipping address as billing address.
         Address billingAddress = Generators.shouldDo(reuseAddressRatio)


### PR DESCRIPTION
We changed the connector to support the extended version of example: https://ibm.github.io/event-automation/tutorials/event-processing-examples/example-12
In this extended version, we want to display the shipping addresses of online orders on Google Maps. If the order is successful, the address will be displayed with a blue marker. In case of out-of-stock, it will be displayed with a red marker.
Since the Faker class is used to generate the addresses, the cities do not actually exist and therefore cannot be displayed on the map. So we introduced a new property in the connector configuration. It is called **onlineorders.cities** and contains a comma separated list of cities. For example:
```
onlineorders.cities=London,Paris,New York,Tokyo,Lima,Bangkok 
```
If this property does not exist, the connector will work as before. But, if it is specified, the *OnlineOrderGenerator* will randomly select one of these cities and assign it to the city in the shipping address when generating the order. 
