### PR TITLE
feat: Introduce headers and keys functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ibm.eventautomation.demos</groupId>
     <artifactId>kafka-connect-loosehangerjeans-source</artifactId>
     <description>Kafka Connect source connector used for generating simulated events for demos and tests</description>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
 
     <developers>
         <developer>

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class DatagenSourceConnector extends SourceConnector {
 
-    protected static final String VERSION = "0.1.2";
+    protected static final String VERSION = "0.1.3";
 
     private final Logger log = LoggerFactory.getLogger(DatagenSourceConnector.class);
 

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/LoosehangerData.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/LoosehangerData.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 
 /**
@@ -54,7 +55,8 @@ public abstract class LoosehangerData {
                                 topicName, topicPartition,
                                 Schema.STRING_SCHEMA, getKey(),
                                 getValueSchema(), getValue(),
-                                timestamp);
+                                timestamp,
+                                getHeaders());
     }
 
     /**
@@ -67,5 +69,10 @@ public abstract class LoosehangerData {
 
     public static Map<String, Object> partition(String origin) {
         return Collections.singletonMap("partition", origin);
+    }
+
+    /** Headers for the message */
+    public ConnectHeaders getHeaders() {
+        return new ConnectHeaders();
     }
 }

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Order.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Order.java
@@ -20,6 +20,7 @@ import java.time.ZonedDateTime;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
 
 /**
  * Represents an event for a new order that has been placed by
@@ -51,6 +52,13 @@ public class Order extends LoosehangerData {
     /** location of the customer */
     private String region;
 
+    /** country code of the order **/
+    private String countryCode;
+
+    private String priority;
+
+    private String storeId;
+
     /** schema for the events - all fields are required */
     private static final Schema SCHEMA = SchemaBuilder.struct()
         .name("order")
@@ -65,7 +73,7 @@ public class Order extends LoosehangerData {
             .field("ordertime",   Schema.STRING_SCHEMA)
         .build();
 
-    public Order(String id, String timestamp, Customer customer, String description, double unitPrice, int quantity, String region, ZonedDateTime recordTimestamp) {
+    public Order(String id, String timestamp, Customer customer, String description, double unitPrice, int quantity, String region, ZonedDateTime recordTimestamp, String countryCode, String priority, String storeId) {
         super(recordTimestamp);
 
         this.id = id;
@@ -75,11 +83,22 @@ public class Order extends LoosehangerData {
         this.unitPrice = unitPrice;
         this.quantity = quantity;
         this.region = region;
+        this.countryCode = countryCode;
+        this.priority = priority;
+        this.storeId = storeId;
     }
 
     @Override
     protected String getKey() {
-        return id;
+        return countryCode;
+    }
+
+    @Override
+    public ConnectHeaders getHeaders() {
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.addString("priority", priority);
+        headers.addString("storeid", storeId);
+        return headers;
     }
 
     @Override
@@ -117,10 +136,20 @@ public class Order extends LoosehangerData {
     public Customer getCustomer() {
         return customer;
     }
+    public String getCountryCode() {
+        return countryCode;
+    }
+    public String getPriority() {
+        return priority;
+    }
+    public String getStoreId() {
+        return storeId;
+    }
 
     @Override
     public String toString() {
         return "Order [id=" + id + ", timestamp=" + timestamp + ", customer=" + customer + ", description="
                 + description + ", unitPrice=" + unitPrice + ", quantity=" + quantity + ", region=" + region + "]";
     }
+
 }

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/SuspiciousOrderGenerator.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/SuspiciousOrderGenerator.java
@@ -76,7 +76,10 @@ public class SuspiciousOrderGenerator {
                                                            initialOrder.getRegion(),
                                                            initialOrder.getDescription(),
                                                            initialOrder.getCustomer(),
-                                                           nextTimestamp);
+                                                           nextTimestamp,
+                                                           initialOrder.getCountryCode(),
+                                                           initialOrder.getPriority(),
+                                                           initialOrder.getStoreId());
                 history.add(largeOrder);
 
                 // cancel the order after a short delay
@@ -102,7 +105,10 @@ public class SuspiciousOrderGenerator {
                             initialOrder.getRegion(),
                             initialOrder.getDescription(),
                             Generators.randomItem(customers),
-                            nextTimestamp);
+                            nextTimestamp,
+                            initialOrder.getCountryCode(),
+                            initialOrder.getPriority(),
+                            initialOrder.getStoreId());
                 history.add(smallOrder);
             }
 

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/DatagenTimerTask.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/DatagenTimerTask.java
@@ -133,7 +133,10 @@ public abstract class DatagenTimerTask extends TimerTask {
             int minNumItems, int maxNumItems,
             double unitPrice,
             String region,
-            String productDescription)
+            String countryCode,
+            String productDescription,
+            String priority,
+            String storeId)
     {
         final Integer cancelDelayMin = null;
         final Integer cancelDelayMax = null;
@@ -143,8 +146,11 @@ public abstract class DatagenTimerTask extends TimerTask {
                       minNumItems, maxNumItems,
                       unitPrice,
                       region,
+                      countryCode,
                       productDescription,
-                      cancelDelayMin, cancelDelayMax);
+                      cancelDelayMin, cancelDelayMax,
+                      priority,
+                      storeId);
     }
 
     protected void scheduleOrder(final String origin, final int delay,
@@ -152,8 +158,11 @@ public abstract class DatagenTimerTask extends TimerTask {
         int minNumItems, int maxNumItems,
         double unitPrice,
         String region,
+        String countryCode,
         String productDescription,
-        Integer cancelDelayMin, Integer cancelDelayMax)
+        Integer cancelDelayMin, Integer cancelDelayMax,
+        String priority,
+        String storeId)
     {
         timer.schedule(new TimerTask() {
             @Override
@@ -162,7 +171,10 @@ public abstract class DatagenTimerTask extends TimerTask {
                                                       unitPrice,
                                                       region,
                                                       productDescription,
-                                                      customer);
+                                                      customer,
+                                                      countryCode,
+                                                      priority,
+                                                      storeId);
                 queue.add(order.createSourceRecord(ordersTopicName, origin));
 
                 if (cancelDelayMin != null && cancelDelayMax != null) {

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/FalsePositivesTask.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/FalsePositivesTask.java
@@ -121,6 +121,9 @@ public class FalsePositivesTask extends DatagenTimerTask {
             Generators.randomPrice(initialOrder.getUnitPrice() - maxPriceVariation,
                                    initialOrder.getUnitPrice() - 0.01),
             initialOrder.getRegion(),
-            initialOrder.getDescription());
+            initialOrder.getCountryCode(),
+            initialOrder.getDescription(),
+            initialOrder.getPriority(),
+            initialOrder.getStoreId());
     }
 }

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/SuspiciousOrdersTask.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/SuspiciousOrdersTask.java
@@ -131,8 +131,11 @@ public class SuspiciousOrdersTask extends DatagenTimerTask {
                           largeOrderMinItems, largeOrderMaxItems,
                           initialOrder.getUnitPrice(),
                           initialOrder.getRegion(),
+                          initialOrder.getCountryCode(),
                           initialOrder.getDescription(),
-                          cancellationMinDelay, cancellationMaxDelay);
+                          cancellationMinDelay, cancellationMaxDelay,
+                          initialOrder.getPriority(),
+                          initialOrder.getStoreId());
 
             suspiciousOrderDelay += delay;
         }
@@ -144,6 +147,9 @@ public class SuspiciousOrdersTask extends DatagenTimerTask {
             Generators.randomPrice(initialOrder.getUnitPrice() - maxPriceVariation,
                                    initialOrder.getUnitPrice() - 0.01),
             initialOrder.getRegion(),
-            initialOrder.getDescription());
+            initialOrder.getCountryCode(),
+            initialOrder.getDescription(),
+            initialOrder.getPriority(),
+            initialOrder.getStoreId());
     }
 }


### PR DESCRIPTION
Introduce headers and keys to the messages in the topic, ORDERS.

The key is country code now, it used to be `id`. Two headers has been added, `priority` and `storeId`. 