### PR TITLE
feat: Update pattern tutorial settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ spec:
     #
     #  these events are intended to represent transaction requests
     #
-    transactions.max.ids: 5
+    transactions.max.ids: 6
     # minimum amount of a transaction
     transactions.amount.min: 100.0
     # maximum amount of a transaction

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ibm.eventautomation.demos</groupId>
     <artifactId>kafka-connect-loosehangerjeans-source</artifactId>
     <description>Kafka Connect source connector used for generating simulated events for demos and tests</description>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
 
     <developers>
         <developer>

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
@@ -707,7 +707,7 @@ public class DatagenSourceConfig {
         //
         .define(CONFIG_TRANSACTIONS_IDS,
                     Type.INT,
-                    5,
+                    6,
                     Range.atLeast(1),
                     Importance.LOW,
                     "Number of transactions identifiers",

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class DatagenSourceConnector extends SourceConnector {
 
-    protected static final String VERSION = "0.3.1";
+    protected static final String VERSION = "0.3.2";
 
     private final Logger log = LoggerFactory.getLogger(DatagenSourceConnector.class);
 

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/TransactionGenerator.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/TransactionGenerator.java
@@ -60,7 +60,7 @@ public class TransactionGenerator extends Generator<Transaction> {
               config.getDouble(DatagenSourceConfig.CONFIG_DUPLICATE_TRANSACTIONS),
               config.getString(DatagenSourceConfig.CONFIG_FORMATS_TIMESTAMPS));
 
-        this.transactionIds = IntStream.range(1, config.getInt(DatagenSourceConfig.CONFIG_TRANSACTIONS_IDS))
+        this.transactionIds = IntStream.rangeClosed(1, config.getInt(DatagenSourceConfig.CONFIG_TRANSACTIONS_IDS))
                                        .mapToObj(number -> "T" + number)
                                        .collect(Collectors.toList());
 


### PR DESCRIPTION
Update pattern tutorial
- increasing the default value for `transactions.max.ids` to 6 to give us a more balanced distribution in topic partitions
- use an inclusive range for transactionId values