### PR TITLE
feat: add new Abandoned orders topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,20 @@ Kafka Connect source connector used for generating simulated events for demos an
 
 It produces messages simulating the following events:
 
-| **Topic name**    | **Description**                                       |
-|-------------------|-------------------------------------------------------|
-| `DOOR.BADGEIN`    | An employee using their id badge to go through a door |
-| `CANCELLATIONS`   | An order being cancelled                              |
-| `CUSTOMERS.NEW`   | A new customer has registered on the website          |
-| `ORDERS.NEW`      | An order has been placed                              |
-| `SENSOR.READINGS` | A sensor reading captured from an IoT sensor          |
-| `STOCK.MOVEMENT`  | Stock shipment received by a warehouse                |
-| `ORDERS.ONLINE`   | An online order has been placed                       |
-| `STOCK.NOSTOCK`   | A product has run out-of-stock                        |
-| `PRODUCT.RETURNS` | A return request has been issued                      |
-| `PRODUCT.REVIEWS` | A product review has been posted                      |
-| `TRANSACTIONS`    | A transaction has been posted                         |
+| **Topic name**      | **Description**                                                                            |
+|---------------------|--------------------------------------------------------------------------------------------|
+| `DOOR.BADGEIN`      | An employee using their id badge to go through a door                                      |
+| `CANCELLATIONS`     | An order being cancelled                                                                   |
+| `CUSTOMERS.NEW`     | A new customer has registered on the website                                               |
+| `ORDERS.NEW`        | An order has been placed                                                                   |
+| `SENSOR.READINGS`   | A sensor reading captured from an IoT sensor                                               |
+| `STOCK.MOVEMENT`    | Stock shipment received by a warehouse                                                     |
+| `ORDERS.ONLINE`     | An online order has been placed                                                            |
+| `STOCK.NOSTOCK`     | A product has run out-of-stock                                                             |
+| `PRODUCT.RETURNS`   | A return request has been issued                                                           |
+| `PRODUCT.REVIEWS`   | A product review has been posted                                                           |
+| `TRANSACTIONS`      | A transaction has been posted                                                              |
+| `ORDERS.ABANDONED`  | A customer has added products to his/her order but left it without completing the purchase |
 
 
 Avro schemas and sample messages for each of these topics can be found in the `./doc` folder.
@@ -84,6 +85,7 @@ spec:
     topic.name.returnrequests: PRODUCT.RETURNS
     topic.name.productreviews: PRODUCT.REVIEWS
     topic.name.transactions: TRANSACTIONS
+    topic.name.abandonedorders: ORDERS.ABANDONED
 
     #
     # startup behavior
@@ -135,6 +137,8 @@ spec:
     timings.ms.productreviews: 60000      # every 1 minute
     # transactions
     timings.ms.transactions: 20000        # every 20 seconds
+    # abandoned orders
+    timings.ms.abandonedorders: 300000    # every 5 minutes
 
     #
     # how much of a delay to introduce when producing events
@@ -175,6 +179,8 @@ spec:
     eventdelays.productreviews.secs.max: 0      # payload time matches event time by default
     # transactions
     eventdelays.transactions.secs.max: 0        # payload time matches event time by default
+    # abandoned orders
+    eventdelays.abandonedorders.secs.max: 0     # payload time matches event time by default
 
     #
     # how many events should be duplicated
@@ -210,6 +216,8 @@ spec:
     duplicates.productreviews.ratio: 0      # events not duplicated
     # transactions
     duplicates.transactions.ratio: 0        # events not duplicated
+    # abandoned orders
+    duplicates.abandonedorders.ratio: 0     # events not duplicated
 
     #
     # product names to use in events
@@ -377,6 +385,18 @@ spec:
     productreviews.delay.ms.max: 3600000  # 1 hour
 
     #
+    # abandoned orders
+    #
+    # these events are intended to represent orders that were abandoned before checkout.
+    #
+    # number of products to include in an abandoned order: between 1 and 5 (inclusive)
+    abandonedorders.products.min: 1
+    abandonedorders.products.max: 5
+    # number of emails for the customer who abandoned the order: between 1 and 2 (inclusive)
+    abandonedorders.customer.emails.min: 1
+    abandonedorders.customer.emails.max: 2
+
+    #
     # locations that are referred to in generated events
     #
     locations.regions: NA,SA,EMEA,APAC,ANZ
@@ -402,7 +422,7 @@ spec:
     # ratio of the transactions that should be a complete sequence of
     #  STARTED -> PROCESSING -> PROCESSING -> COMPLETED
     transactions.valid.ratio: 0.8  # 80% of transactions are complete
-                                   # 20% of transactions omit an event
+    # 20% of transactions omit an event
 ```
 
 For example, if you want to theme the demo to be based on products in a different industry, you could adjust product sizes/materials/styles/name to match your demo (the options don't need to actually be "sizes", "materials" or "styles" - they just need to be lists that will make sense when combined into a single string).

--- a/doc/ORDERS.ABANDONED/sample.json
+++ b/doc/ORDERS.ABANDONED/sample.json
@@ -1,0 +1,15 @@
+{
+  "cartid": "c5a4e2fc-13ee-4fde-b4f2-4a22b565d09d",
+  "customer": {
+    "id": "573b6b1d-6070-4f4b-afb1-be480554930a",
+    "name": "Inger Orn",
+    "emails": [
+      "inger.orn@example.com"
+    ]
+  },
+  "products": [
+    "Navy Capri Jeans",
+    "Retro Crochet Jeans"
+  ],
+  "abandonedtime": "2025-04-24T20:01:32.136Z"
+}

--- a/doc/ORDERS.ABANDONED/schema.avro
+++ b/doc/ORDERS.ABANDONED/schema.avro
@@ -1,0 +1,59 @@
+{
+  "namespace": "com.loosehangerjeans",
+  "type": "record",
+  "name": "AbandonedOrder",
+  "fields": [
+    {
+      "name": "cartid",
+      "doc": "Unique ID for the abandoned order",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+    },
+    {
+      "name": "customer",
+      "doc": "Customer who abandoned products in the order",
+      "type": {
+        "type": "record",
+        "name": "Customer",
+        "fields": [
+          {
+            "name": "id",
+            "type": {
+              "type": "string",
+              "logicalType": "uuid"
+            },
+            "doc": "Unique id for the customer"
+          },
+          {
+            "name": "name",
+            "type": "string",
+            "doc": "Name of the customer"
+          },
+          {
+            "name": "emails",
+            "type": {
+              "type": "array",
+              "items": "string"
+            },
+            "doc": "Emails of the customer"
+          }
+        ]
+      }
+    },
+    {
+      "name": "products",
+      "doc": "Descriptions of the abandoned order products",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    },
+    {
+      "name": "abandonedtime",
+      "doc": "Time at which the shopping cart was determined to be abandoned after a period of inactivity (UTC time in ISO 8601 format).",
+      "type": "string"
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ibm.eventautomation.demos</groupId>
     <artifactId>kafka-connect-loosehangerjeans-source</artifactId>
     <description>Kafka Connect source connector used for generating simulated events for demos and tests</description>
-    <version>0.3.2</version>
+    <version>0.4.0</version>
 
     <developers>
         <developer>

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConfig.java
@@ -38,17 +38,18 @@ public class DatagenSourceConfig {
     public static final String CONFIG_FORMATS_TIMESTAMPS_LTZ    = "formats.timestamps.ltz";
 
     private static final String CONFIG_GROUP_TOPICNAMES = "Topic names";
-    public static final String CONFIG_TOPICNAME_ORDERS         = "topic.name.orders";
-    public static final String CONFIG_TOPICNAME_CANCELLATIONS  = "topic.name.cancellations";
-    public static final String CONFIG_TOPICNAME_STOCKMOVEMENTS = "topic.name.stockmovements";
-    public static final String CONFIG_TOPICNAME_BADGEINS       = "topic.name.badgeins";
-    public static final String CONFIG_TOPICNAME_CUSTOMERS      = "topic.name.newcustomers";
-    public static final String CONFIG_TOPICNAME_SENSORREADINGS = "topic.name.sensorreadings";
-    public static final String CONFIG_TOPICNAME_ONLINEORDERS   = "topic.name.onlineorders";
-    public static final String CONFIG_TOPICNAME_OUTOFSTOCKS    = "topic.name.outofstocks";
-    public static final String CONFIG_TOPICNAME_RETURNREQUESTS = "topic.name.returnrequests";
-    public static final String CONFIG_TOPICNAME_PRODUCTREVIEWS = "topic.name.productreviews";
-    public static final String CONFIG_TOPICNAME_TRANSACTIONS   = "topic.name.transactions";
+    public static final String CONFIG_TOPICNAME_ORDERS                  = "topic.name.orders";
+    public static final String CONFIG_TOPICNAME_CANCELLATIONS           = "topic.name.cancellations";
+    public static final String CONFIG_TOPICNAME_STOCKMOVEMENTS          = "topic.name.stockmovements";
+    public static final String CONFIG_TOPICNAME_BADGEINS                = "topic.name.badgeins";
+    public static final String CONFIG_TOPICNAME_CUSTOMERS               = "topic.name.newcustomers";
+    public static final String CONFIG_TOPICNAME_SENSORREADINGS          = "topic.name.sensorreadings";
+    public static final String CONFIG_TOPICNAME_ONLINEORDERS            = "topic.name.onlineorders";
+    public static final String CONFIG_TOPICNAME_OUTOFSTOCKS             = "topic.name.outofstocks";
+    public static final String CONFIG_TOPICNAME_RETURNREQUESTS          = "topic.name.returnrequests";
+    public static final String CONFIG_TOPICNAME_PRODUCTREVIEWS          = "topic.name.productreviews";
+    public static final String CONFIG_TOPICNAME_TRANSACTIONS            = "topic.name.transactions";
+    public static final String CONFIG_TOPICNAME_ABANDONEDORDERS         = "topic.name.abandonedorders";
 
     private static final String CONFIG_GROUP_LOCATIONS = "Locations";
     public static final String CONFIG_LOCATIONS_REGIONS    = "locations.regions";
@@ -132,45 +133,54 @@ public class DatagenSourceConfig {
     public static final String CONFIG_TRANSACTIONS_AMOUNT_MAX  = "transactions.amount.max";
     public static final String CONFIG_TRANSACTIONS_VALID_RATIO = "transactions.valid.ratio";
 
+    private static final String CONFIG_GROUP_ABANDONEDORDERS = "Abandoned orders";
+    public static final String CONFIG_ABANDONEDORDERS_PRODUCTS_MIN           = "abandonedorders.products.min";
+    public static final String CONFIG_ABANDONEDORDERS_PRODUCTS_MAX           = "abandonedorders.products.max";
+    public static final String CONFIG_ABANDONEDORDERS_CUSTOMER_EMAILS_MIN    = "abandonedorders.customer.emails.min";
+    public static final String CONFIG_ABANDONEDORDERS_CUSTOMER_EMAILS_MAX    = "abandonedorders.customer.emails.max";
+
     private static final String CONFIG_GROUP_DELAYS = "Event delays";
-    public static final String CONFIG_DELAYS_ORDERS         = "eventdelays.orders.secs.max";
-    public static final String CONFIG_DELAYS_CANCELLATIONS  = "eventdelays.cancellations.secs.max";
-    public static final String CONFIG_DELAYS_STOCKMOVEMENTS = "eventdelays.stockmovements.secs.max";
-    public static final String CONFIG_DELAYS_BADGEINS       = "eventdelays.badgeins.secs.max";
-    public static final String CONFIG_DELAYS_NEWCUSTOMERS   = "eventdelays.newcustomers.secs.max";
-    public static final String CONFIG_DELAYS_SENSORREADINGS = "eventdelays.sensorreadings.secs.max";
-    public static final String CONFIG_DELAYS_ONLINEORDERS   = "eventdelays.onlineorders.secs.max";
-    public static final String CONFIG_DELAYS_OUTOFSTOCKS    = "eventdelays.outofstocks.secs.max";
-    public static final String CONFIG_DELAYS_RETURNREQUESTS   = "eventdelays.returnrequests.secs.max";
-    public static final String CONFIG_DELAYS_PRODUCTREVIEWS   = "eventdelays.productreviews.secs.max";
-    public static final String CONFIG_DELAYS_TRANSACTIONS     = "eventdelays.transactions.secs.max";
+    public static final String CONFIG_DELAYS_ORDERS                 = "eventdelays.orders.secs.max";
+    public static final String CONFIG_DELAYS_CANCELLATIONS          = "eventdelays.cancellations.secs.max";
+    public static final String CONFIG_DELAYS_STOCKMOVEMENTS         = "eventdelays.stockmovements.secs.max";
+    public static final String CONFIG_DELAYS_BADGEINS               = "eventdelays.badgeins.secs.max";
+    public static final String CONFIG_DELAYS_NEWCUSTOMERS           = "eventdelays.newcustomers.secs.max";
+    public static final String CONFIG_DELAYS_SENSORREADINGS         = "eventdelays.sensorreadings.secs.max";
+    public static final String CONFIG_DELAYS_ONLINEORDERS           = "eventdelays.onlineorders.secs.max";
+    public static final String CONFIG_DELAYS_OUTOFSTOCKS            = "eventdelays.outofstocks.secs.max";
+    public static final String CONFIG_DELAYS_RETURNREQUESTS         = "eventdelays.returnrequests.secs.max";
+    public static final String CONFIG_DELAYS_PRODUCTREVIEWS         = "eventdelays.productreviews.secs.max";
+    public static final String CONFIG_DELAYS_TRANSACTIONS           = "eventdelays.transactions.secs.max";
+    public static final String CONFIG_DELAYS_ABANDONEDORDERS        = "eventdelays.abandonedorders.secs.max";
 
     private static final String CONFIG_GROUP_DUPLICATES = "Duplicate events";
-    public static final String CONFIG_DUPLICATE_ORDERS         = "duplicates.orders.ratio";
-    public static final String CONFIG_DUPLICATE_CANCELLATIONS  = "duplicates.cancellations.ratio";
-    public static final String CONFIG_DUPLICATE_STOCKMOVEMENTS = "duplicates.stockmovements.ratio";
-    public static final String CONFIG_DUPLICATE_BADGEINS       = "duplicates.badgeins.ratio";
-    public static final String CONFIG_DUPLICATE_NEWCUSTOMERS   = "duplicates.newcustomers.ratio";
-    public static final String CONFIG_DUPLICATE_SENSORREADINGS = "duplicates.sensorreadings.ratio";
-    public static final String CONFIG_DUPLICATE_ONLINEORDERS   = "duplicates.onlineorders.ratio";
-    public static final String CONFIG_DUPLICATE_OUTOFSTOCKS    = "duplicates.outofstocks.ratio";
-    public static final String CONFIG_DUPLICATE_RETURNREQUESTS = "duplicates.returnrequests.ratio";
-    public static final String CONFIG_DUPLICATE_PRODUCTREVIEWS = "duplicates.productreviews.ratio";
-    public static final String CONFIG_DUPLICATE_TRANSACTIONS   = "duplicates.transactions.ratio";
+    public static final String CONFIG_DUPLICATE_ORDERS                  = "duplicates.orders.ratio";
+    public static final String CONFIG_DUPLICATE_CANCELLATIONS           = "duplicates.cancellations.ratio";
+    public static final String CONFIG_DUPLICATE_STOCKMOVEMENTS          = "duplicates.stockmovements.ratio";
+    public static final String CONFIG_DUPLICATE_BADGEINS                = "duplicates.badgeins.ratio";
+    public static final String CONFIG_DUPLICATE_NEWCUSTOMERS            = "duplicates.newcustomers.ratio";
+    public static final String CONFIG_DUPLICATE_SENSORREADINGS          = "duplicates.sensorreadings.ratio";
+    public static final String CONFIG_DUPLICATE_ONLINEORDERS            = "duplicates.onlineorders.ratio";
+    public static final String CONFIG_DUPLICATE_OUTOFSTOCKS             = "duplicates.outofstocks.ratio";
+    public static final String CONFIG_DUPLICATE_RETURNREQUESTS          = "duplicates.returnrequests.ratio";
+    public static final String CONFIG_DUPLICATE_PRODUCTREVIEWS          = "duplicates.productreviews.ratio";
+    public static final String CONFIG_DUPLICATE_TRANSACTIONS            = "duplicates.transactions.ratio";
+    public static final String CONFIG_DUPLICATE_ABANDONEDORDERS         = "duplicates.abandonedorders.ratio";
 
     private static final String CONFIG_GROUP_TIMES = "Timings";
-    public static final String CONFIG_TIMES_ORDERS             = "timings.ms.orders";
-    public static final String CONFIG_TIMES_FALSEPOSITIVES     = "timings.ms.falsepositives";
-    public static final String CONFIG_TIMES_SUSPICIOUSORDERS   = "timings.ms.suspiciousorders";
-    public static final String CONFIG_TIMES_STOCKMOVEMENTS     = "timings.ms.stockmovements";
-    public static final String CONFIG_TIMES_BADGEINS           = "timings.ms.badgeins";
-    public static final String CONFIG_TIMES_NEWCUSTOMERS       = "timings.ms.newcustomers";
-    public static final String CONFIG_TIMES_SENSORREADINGS     = "timings.ms.sensorreadings";
-    public static final String CONFIG_TIMES_HIGHSENSORREADINGS = "timings.ms.highsensorreadings";
-    public static final String CONFIG_TIMES_ONLINEORDERS       = "timings.ms.onlineorders";
-    public static final String CONFIG_TIMES_RETURNREQUESTS     = "timings.ms.returnrequests";
-    public static final String CONFIG_TIMES_PRODUCTREVIEWS     = "timings.ms.productreviews";
+    public static final String CONFIG_TIMES_ORDERS                  = "timings.ms.orders";
+    public static final String CONFIG_TIMES_FALSEPOSITIVES          = "timings.ms.falsepositives";
+    public static final String CONFIG_TIMES_SUSPICIOUSORDERS        = "timings.ms.suspiciousorders";
+    public static final String CONFIG_TIMES_STOCKMOVEMENTS          = "timings.ms.stockmovements";
+    public static final String CONFIG_TIMES_BADGEINS                = "timings.ms.badgeins";
+    public static final String CONFIG_TIMES_NEWCUSTOMERS            = "timings.ms.newcustomers";
+    public static final String CONFIG_TIMES_SENSORREADINGS          = "timings.ms.sensorreadings";
+    public static final String CONFIG_TIMES_HIGHSENSORREADINGS      = "timings.ms.highsensorreadings";
+    public static final String CONFIG_TIMES_ONLINEORDERS            = "timings.ms.onlineorders";
+    public static final String CONFIG_TIMES_RETURNREQUESTS          = "timings.ms.returnrequests";
+    public static final String CONFIG_TIMES_PRODUCTREVIEWS          = "timings.ms.productreviews";
     public static final String CONFIG_TIMES_TRANSACTIONS       = "timings.ms.transactions";
+    public static final String CONFIG_TIMES_ABANDONEDORDERS         = "timings.ms.abandonedorders";
 
     private static final String CONFIG_GROUP_BEHAVIOR = "Behavior";
     public static final String CONFIG_BEHAVIOR_STARTUPHISTORY = "startup.history.enabled";
@@ -277,6 +287,13 @@ public class DatagenSourceConfig {
                     "Name of the topic to use for transaction events",
                     CONFIG_GROUP_TOPICNAMES, 11, Width.LONG, "Transactions topic")
 
+        .define(CONFIG_TOPICNAME_ABANDONEDORDERS,
+                    Type.STRING,
+                    "ORDERS.ABANDONED",
+                    new NonEmptyString(),
+                    Importance.LOW,
+                    "Name of the topic to use for abandoned order events",
+                    CONFIG_GROUP_TOPICNAMES, 11, Width.LONG, "Abandoned orders topic")
         //
         // how to generate locations
         //
@@ -735,6 +752,37 @@ public class DatagenSourceConfig {
                     CONFIG_GROUP_TRANSACTIONS, 4, Width.SHORT, "Valid transactions ratio")
 
         //
+        // Generating abandoned orders
+        //
+        .define(CONFIG_ABANDONEDORDERS_PRODUCTS_MIN,
+                    Type.INT,
+                    1,
+                    Range.atLeast(1),
+                    Importance.LOW,
+                    "Minimum number of products in an abandoned order. Must be greater than 0.",
+                    CONFIG_GROUP_ABANDONEDORDERS, 1, Width.SHORT, "Min product count")
+        .define(CONFIG_ABANDONEDORDERS_PRODUCTS_MAX,
+                    Type.INT,
+                    5,
+                    Range.atLeast(1),
+                    Importance.LOW,
+                    "Maximum number of products in an abandoned order. Must be greater than 0.",
+                    CONFIG_GROUP_ABANDONEDORDERS, 2, Width.SHORT, "Max product count")
+        .define(CONFIG_ABANDONEDORDERS_CUSTOMER_EMAILS_MIN,
+                    Type.INT,
+                    1,
+                    Range.atLeast(1),
+                    Importance.LOW,
+                    "Minimum number of emails for a customer in an abandoned order. Must be greater than 0.",
+                    CONFIG_GROUP_ABANDONEDORDERS, 3, Width.SHORT, "Min customer email count")
+        .define(CONFIG_ABANDONEDORDERS_CUSTOMER_EMAILS_MAX,
+                    Type.INT,
+                    2,
+                    Range.atLeast(1),
+                    Importance.LOW,
+                    "Maximum number of emails for a customer in an abandoned order. Must be greater than 0.",
+                    CONFIG_GROUP_ABANDONEDORDERS, 4, Width.SHORT, "Max customer email count")
+        //
         // how long to delay messages before producing them to Kafka
         //
         .define(CONFIG_DELAYS_ORDERS,
@@ -814,6 +862,13 @@ public class DatagenSourceConfig {
                     Importance.LOW,
                     "Maximum delay (in *seconds*) to produce transaction events (this is the maximum difference allowed between the timestamp string in the event payload, and the Kafka message's metadata timestamp)",
                     CONFIG_GROUP_DELAYS, 11, Width.SHORT, "Transaction events - max produce delay")
+        .define(CONFIG_DELAYS_ABANDONEDORDERS,
+                    Type.INT,
+                    0, // payload time matching event time by default
+                    Range.between(0, 900),  // up to 15 mins max
+                    Importance.LOW,
+                    "Maximum delay (in *seconds*) to produce new abandoned order events (this is the maximum difference allowed between the timestamp string in the event payload, and the Kafka message's metadata timestamp)",
+                    CONFIG_GROUP_DELAYS, 11, Width.SHORT, "Abandoned order events - max produce delay")
 
         //
         // likelihood of producing duplicate messages
@@ -895,6 +950,13 @@ public class DatagenSourceConfig {
                     Importance.LOW,
                     "Ratio of transaction events that should be duplicated. Must be between 0 and 1.",
                     CONFIG_GROUP_DUPLICATES, 11, Width.SHORT, "Duplicate transaction events ratio")
+       .define(CONFIG_DUPLICATE_ABANDONEDORDERS,
+                    Type.DOUBLE,
+                    0,   // don't create duplicate events by default
+                    Range.between(0.0, 1.0), // ratio should be between 0 (don't create duplicates) and 1 (duplicate every message)
+                    Importance.LOW,
+                    "Ratio of abandoned order events that should be duplicated. Must be between 0 and 1.",
+                    CONFIG_GROUP_DUPLICATES, 11, Width.SHORT, "Duplicate abandoned order events ratio")
 
         //
         // How frequently to generate messages
@@ -983,6 +1045,13 @@ public class DatagenSourceConfig {
                     Importance.LOW,
                     "Delay, in milliseconds, between each transaction that should be generated.",
                     CONFIG_GROUP_TIMES, 12, Width.MEDIUM, "Sensor readings delay")
+        .define(CONFIG_TIMES_ABANDONEDORDERS,
+                    Type.INT,
+                    300_000, // 5 minutes
+                    Range.atLeast(500),
+                    Importance.LOW,
+                    "Delay, in milliseconds, between each abandoned order that should be generated.",
+                    CONFIG_GROUP_TIMES, 12, Width.MEDIUM, "Abandoned orders delay")
 
         //
         // Startup behaviour

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class DatagenSourceConnector extends SourceConnector {
 
-    protected static final String VERSION = "0.3.2";
+    protected static final String VERSION = "0.4.0";
 
     private final Logger log = LoggerFactory.getLogger(DatagenSourceConnector.class);
 

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceTask.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceTask.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import com.ibm.eventautomation.demos.loosehangerjeans.data.Product;
 import com.ibm.eventautomation.demos.loosehangerjeans.generators.ProductGenerator;
 import com.ibm.eventautomation.demos.loosehangerjeans.generators.ProductReviewGenerator;
+import com.ibm.eventautomation.demos.loosehangerjeans.tasks.AbandonedOrdersTask;
 import com.ibm.eventautomation.demos.loosehangerjeans.tasks.BadgeInTask;
 import com.ibm.eventautomation.demos.loosehangerjeans.tasks.FalsePositivesTask;
 import com.ibm.eventautomation.demos.loosehangerjeans.tasks.HighSensorReadingTask;
@@ -143,6 +144,9 @@ public class DatagenSourceTask extends SourceTask {
         // transactions
         TransactionTask transactions = new TransactionTask(config, queue);
         generateTimer.scheduleAtFixedRate(transactions, 0, config.getInt(DatagenSourceConfig.CONFIG_TIMES_TRANSACTIONS));
+        // abandoned orders
+        AbandonedOrdersTask abandonedOrders = new AbandonedOrdersTask(config, queue, generateTimer);
+        generateTimer.scheduleAtFixedRate(abandonedOrders, 0, config.getInt(DatagenSourceConfig.CONFIG_TIMES_ABANDONEDORDERS));
     }
 
 

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/AbandonedOrder.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/AbandonedOrder.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2025 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.ibm.eventautomation.demos.loosehangerjeans.data;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Represents an event for an abandoned order.
+ * Each event includes customer information and a list of products
+ * left in the cart when it was abandoned.
+ */
+
+public class AbandonedOrder extends LoosehangerData {
+
+    public static final String PARTITION = "abandonedorder";
+
+    /** Unique ID for the abandoned cart */
+    private final String cartId;
+
+    /** Time that the cart was considered abandoned */
+    private final String abandonedTimestamp;
+
+    /** Details of the customer who made the order. */
+    private final OnlineCustomer customer;
+
+    /** List of products left in the cart */
+    private final List<String> products;
+
+    /** Schema for the events - all fields are required. */
+    private static final Schema SCHEMA = SchemaBuilder.struct()
+            .name("abandonedorder")
+            .version(1)
+            .field("cartid",        Schema.STRING_SCHEMA)
+            .field("customer",      OnlineCustomer.SCHEMA)
+            .field("products",      SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+            .field("abandonedtime", Schema.STRING_SCHEMA)
+            .build();
+
+    /** Creates an {@link AbandonedOrder} using the provided details */
+    public AbandonedOrder(String cartId, String abandonedTimestamp, OnlineCustomer customer, List<String> products, ZonedDateTime recordTimestamp) {
+        super(recordTimestamp);
+        this.cartId = cartId;
+        this.abandonedTimestamp = abandonedTimestamp;
+        this.customer = customer;
+        this.products = products;
+    }
+
+    /** Creates an {@link AbandonedOrder} using the provided details.
+     * The ID is generated randomly.
+     * */
+    public AbandonedOrder(String abandonedTimestamp, OnlineCustomer customer, List<String> products, ZonedDateTime recordTimestamp) {
+        this(UUID.randomUUID().toString(), abandonedTimestamp, customer, products, recordTimestamp);
+    }
+
+    public String getAbandonedTimestamp() {
+        return abandonedTimestamp;
+    }
+
+    public String getCartId() {
+        return cartId;
+    }
+
+    public OnlineCustomer getCustomer() {
+        return customer;
+    }
+
+    public List<String> getProducts() {
+        return products;
+    }
+
+    public SourceRecord createSourceRecord(String topicName) {
+        return super.createSourceRecord(topicName, PARTITION);
+    }
+
+    @Override
+    protected String getKey() {
+        return cartId;
+    }
+
+    @Override
+    protected Schema getValueSchema() {
+        return SCHEMA;
+    }
+
+    @Override
+    protected Struct getValue() {
+        Struct struct = new Struct(SCHEMA);
+        struct.put(SCHEMA.field("cartid"),      cartId);
+        struct.put(SCHEMA.field("customer"),    customer.toStruct());
+        struct.put(SCHEMA.field("products"),    products);
+        struct.put(SCHEMA.field("abandonedtime"), abandonedTimestamp);
+        return struct;
+    }
+
+    @Override
+    public String toString() {
+        return "AbandonedOrder [cartId=" + cartId + ", abandonedTimestamp=" + abandonedTimestamp + ", customer=" + customer + ", products="
+                + Arrays.toString(products.toArray()) + "]";
+    }
+}

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/AbandonedOrderGenerator.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/AbandonedOrderGenerator.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2025 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.ibm.eventautomation.demos.loosehangerjeans.generators;
+
+import com.ibm.eventautomation.demos.loosehangerjeans.DatagenSourceConfig;
+import com.ibm.eventautomation.demos.loosehangerjeans.data.AbandonedOrder;
+import com.ibm.eventautomation.demos.loosehangerjeans.data.OnlineCustomer;
+import com.ibm.eventautomation.demos.loosehangerjeans.utils.Generators;
+import org.apache.kafka.common.config.AbstractConfig;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Generates an {@link AbandonedOrder} event using randomly generated data.
+ */
+public class AbandonedOrderGenerator extends Generator<AbandonedOrder> {
+
+    /** Helper class to randomly generate product details */
+    private final ProductGenerator productGenerator;
+
+    /** Minimum number of products in a order */
+    private final int minProducts;
+
+    /** Maximum number of products in a order */
+    private final int maxProducts;
+
+    /** Minimum number of emails for the customer who abandons the cart */
+    private final int minEmails;
+
+    /** Maximum number of emails for the customer who abandons the cart */
+    private final int maxEmails;
+
+    /** Creates an {@link AbandonedOrderGenerator} using the provided configuration. */
+    public AbandonedOrderGenerator(AbstractConfig config) {
+        super(config.getInt(DatagenSourceConfig.CONFIG_TIMES_ABANDONEDORDERS),
+                config.getInt(DatagenSourceConfig.CONFIG_DELAYS_ABANDONEDORDERS),
+                config.getDouble(DatagenSourceConfig.CONFIG_DUPLICATE_ABANDONEDORDERS),
+                config.getString(DatagenSourceConfig.CONFIG_FORMATS_TIMESTAMPS_LTZ));
+
+        this.productGenerator = new ProductGenerator(config);
+        this.minProducts = config.getInt(DatagenSourceConfig.CONFIG_ABANDONEDORDERS_PRODUCTS_MIN);
+        this.maxProducts = config.getInt(DatagenSourceConfig.CONFIG_ABANDONEDORDERS_PRODUCTS_MAX);
+        this.minEmails = config.getInt(DatagenSourceConfig.CONFIG_ABANDONEDORDERS_CUSTOMER_EMAILS_MIN);
+        this.maxEmails = config.getInt(DatagenSourceConfig.CONFIG_ABANDONEDORDERS_CUSTOMER_EMAILS_MIN);
+    }
+
+    @Override
+    protected AbandonedOrder generateEvent(ZonedDateTime timestamp) {
+        // Generate a random customer
+        OnlineCustomer customer = OnlineCustomer.create(faker, minEmails, maxEmails);
+        // Generate some products randomly.
+        int productCount = Generators.randomInt(minProducts, maxProducts);
+        List<String> cartProducts = new ArrayList<>();
+        for (int i = 0; i < productCount; i++) {
+            cartProducts.add(productGenerator.generate().getShortDescription());
+        }
+
+        return new AbandonedOrder(formatTimestamp(timestamp), customer, cartProducts, timestamp);
+    }
+}

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/AbandonedOrdersTask.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/tasks/AbandonedOrdersTask.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.ibm.eventautomation.demos.loosehangerjeans.tasks;
+
+import com.ibm.eventautomation.demos.loosehangerjeans.DatagenSourceConfig;
+import com.ibm.eventautomation.demos.loosehangerjeans.data.AbandonedOrder;
+import com.ibm.eventautomation.demos.loosehangerjeans.generators.AbandonedOrderGenerator;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.Queue;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Timer task intended for repeated execution. Creates new
+ * {@link AbandonedOrder} events at regular intervals
+ */
+public class AbandonedOrdersTask extends TimerTask {
+
+    /** Helper class for generating AbandonedOrder events */
+    private final AbandonedOrderGenerator abandonedOrderGenerator;
+
+    /**
+     * Queue of messages waiting to be delivered to Kafka.
+     * Generated AbandonedOrder events will be added to this queue
+     */
+    private final Queue<SourceRecord> queue;
+
+    /** Timer used to schedule message-generation tasks. */
+    private final Timer timer;
+
+    /** Name of the topic to produce abandoned order events to. */
+    private final String abandonedOrderTopicName;
+
+    public AbandonedOrdersTask(AbstractConfig config,
+                            Queue<SourceRecord> queue,
+                            Timer generateTimer) {
+        this.abandonedOrderGenerator = new AbandonedOrderGenerator(config);
+        this.queue = queue;
+        this.timer = generateTimer;
+        this.abandonedOrderTopicName = config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_ABANDONEDORDERS);
+    }
+
+    @Override
+    public void run() {
+        // Generate a random abandoned order event.
+        AbandonedOrder abandonedOrder = abandonedOrderGenerator.generate();
+        SourceRecord rec = abandonedOrder.createSourceRecord(abandonedOrderTopicName);
+        queue.add(rec);
+
+        // Possibly duplicate the event.
+        if (abandonedOrderGenerator.shouldDuplicate()) {
+            queue.add(rec);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the generation of events for the new topic - ORDERS.ABANDONED (events generated for orders which are left without completing the purchase)