### PR TITLE
fix: prevent historical events generated with future timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.ibm.eventautomation.demos</groupId>
     <artifactId>kafka-connect-loosehangerjeans-source</artifactId>
     <description>Kafka Connect source connector used for generating simulated events for demos and tests</description>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
 
     <developers>
         <developer>
@@ -96,6 +96,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenHistory.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenHistory.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2025 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventautomation.demos.loosehangerjeans;
+
+import java.time.Instant;
+import java.util.ArrayList;
+
+import org.apache.kafka.connect.source.SourceRecord;
+
+/**
+ * A collection of Connect SourceRecord objects, that enforces a
+ *  requirement that all records must be historical.
+ *
+ * SourceRecord elements with a timestamp that is greater than
+ *  the timestamp specified when the collection is created can not
+ *  be added.
+ */
+public class DatagenHistory extends ArrayList<SourceRecord> {
+
+    final long max;
+
+    public DatagenHistory(Instant maxTimestamp) {
+        max = maxTimestamp.toEpochMilli();
+    }
+
+    @Override
+    public boolean add(SourceRecord e) {
+        if (e.timestamp() < max) {
+            return super.add(e);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenHistoryGenerator.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenHistoryGenerator.java
@@ -15,8 +15,8 @@
  */
 package com.ibm.eventautomation.demos.loosehangerjeans;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +92,7 @@ public class DatagenHistoryGenerator {
     {
         log.info("Generating historical events to warm up the topics");
 
-        List<SourceRecord> historicalRecords = new ArrayList<>();
+        DatagenHistory historicalRecords = new DatagenHistory(Instant.now());
 
         addNewCustomerRecords(historicalRecords, config);
         addStockMovementRecords(historicalRecords, config);

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenSourceConnector.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public class DatagenSourceConnector extends SourceConnector {
 
-    protected static final String VERSION = "0.5.1";
+    protected static final String VERSION = "0.5.2";
 
     private final Logger log = LoggerFactory.getLogger(DatagenSourceConnector.class);
 

--- a/src/test/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenHistoryGeneratorTest.java
+++ b/src/test/java/com/ibm/eventautomation/demos/loosehangerjeans/DatagenHistoryGeneratorTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2025 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.ibm.eventautomation.demos.loosehangerjeans;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.source.SourceRecord;
+
+
+
+
+public class DatagenHistoryGeneratorTest {
+
+    @Test
+    public void testHistoryEvents() {
+        AbstractConfig config = new AbstractConfig(DatagenSourceConfig.CONFIG_DEF, Collections.EMPTY_MAP);
+
+        final long now = Instant.now().toEpochMilli();
+        List<String> expectedTopicNames = new ArrayList<>(Arrays.asList(
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_ORDERS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_CANCELLATIONS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_STOCKMOVEMENTS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_BADGEINS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_CUSTOMERS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_SENSORREADINGS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_ONLINEORDERS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_OUTOFSTOCKS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_RETURNREQUESTS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_PRODUCTREVIEWS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_TRANSACTIONS),
+            config.getString(DatagenSourceConfig.CONFIG_TOPICNAME_ABANDONEDORDERS)
+        ));
+
+        List<SourceRecord> records = new DatagenHistoryGenerator().generateHistory(config);
+
+        assertTrue(
+            records.size() > 1_100_000,
+            "Unexpectedly small number of events (" + records.size() + ") generated");
+
+        for (SourceRecord record : records) {
+            long timestamp = record.timestamp();
+
+            assertFalse(
+                timestamp > now,
+                "Event timestamp " + timestamp +
+                    " for historical event on " + record.topic() +
+                    " is in the future (current time: " + now + ")");
+
+            expectedTopicNames.remove(record.topic());
+        }
+
+        assertTrue(
+            expectedTopicNames.isEmpty(),
+            "No historical records generated for topics " +
+                String.join(",", expectedTopicNames));
+    }
+}
+


### PR DESCRIPTION
Optionally, on startup for the first time, the Connector can generate a week's worth of events with timestamps intentionally backdated to make it look like the Connector has been running and emitting events for a week. This is a useful feature for rapidly setting up a demo suitable for using event stream processing to perform historical analysis.

In very rare situations, this can produce events with a timestamp that is greater than an hour after the current timestamp - which results in an InvalidTimestampException.

This commit is a brute force protection against that by silently discarding any events generated by DatagenHistoryGenerator that have a future timestamp.

I did consider a more careful approach that identifies and fixes exactly the circumstances that can result in a future timestamp being generated, but that didn't feel warranted given that this is only a synthetic data generator for demos. Plus this approach will more easily catch any future regressions in this area too.