### PR TITLE
chore: replace faker library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>1.0.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.13.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Address.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Address.java
@@ -15,7 +15,7 @@
  */
 package com.ibm.eventautomation.demos.loosehangerjeans.data;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import com.ibm.eventautomation.demos.loosehangerjeans.utils.Generators;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -85,7 +85,7 @@ public class Address {
         }
 
         // Generate the address.
-        com.github.javafaker.Address fakerAddress = faker.address();
+        net.datafaker.providers.base.Address fakerAddress = faker.address();
         return new Address(Integer.valueOf(fakerAddress.streetAddressNumber()),
                 fakerAddress.streetName(),
                 fakerAddress.cityName(),

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Customer.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/Customer.java
@@ -17,7 +17,7 @@ package com.ibm.eventautomation.demos.loosehangerjeans.data;
 
 import java.util.UUID;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 
 /**
  * Information about a customer.

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/OnlineCustomer.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/data/OnlineCustomer.java
@@ -15,9 +15,8 @@
  */
 package com.ibm.eventautomation.demos.loosehangerjeans.data;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import com.ibm.eventautomation.demos.loosehangerjeans.utils.Generators;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -66,7 +65,7 @@ public class OnlineCustomer extends Customer {
         String username = faker.name().username();
         String[] nameParts = username.split("\\.");
         // Compute the corresponding full name.
-        String fullName = StringUtils.capitalize(nameParts[0]) + " " + StringUtils.capitalize(nameParts[1]);
+        String fullName = capitalize(nameParts[0]) + " " + capitalize(nameParts[1]);
 
         // Generate some emails randomly for this customer.
         int emailCount = Generators.randomInt(minEmails, maxEmails);
@@ -98,5 +97,15 @@ public class OnlineCustomer extends Customer {
     @Override
     public String toString() {
         return "Customer [id=" + getId() + ", name=" + getName() + ", emails="  + Arrays.toString(emails.toArray()) + "]";
+    }
+
+    private static String capitalize(String str) {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        if (str.length() == 1) {
+            return str.toUpperCase();
+        }
+        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
     }
 }

--- a/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/Generator.java
+++ b/src/main/java/com/ibm/eventautomation/demos/loosehangerjeans/generators/Generator.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import com.ibm.eventautomation.demos.loosehangerjeans.utils.Generators;
 
 


### PR DESCRIPTION
The Faker implementation used to generate data was quite old, and not actively maintained. It was bringing in old transitive depdenencies that had known vulnerabilities.

This commit switches to a new, actively maintained alternative.

Closes: #18